### PR TITLE
FIX: When tags are not specified, enable everywhere

### DIFF
--- a/javascripts/discourse/initializers/init-topic-excerpts.js
+++ b/javascripts/discourse/initializers/init-topic-excerpts.js
@@ -7,7 +7,7 @@ const enabledCategories = settings.enabled_categories
   .map((id) => parseInt(id, 10))
   .filter((id) => id);
 
-const enabledTags = settings.enabled_tags.split("|");
+const enabledTags = settings.enabled_tags.split("|").filter((tag) => tag);
 
 export default {
   name: "topic-excerpts-init",


### PR DESCRIPTION
When splitting an empty string, js will return an empty string. Therefore we need to filter out those empty values before calling `.length`