### PR TITLE
FEATURE: add optional excerpt toggle

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -9,9 +9,3 @@
     margin-top: 0.5em;
   }
 }
-
-body.hide-excerpt {
-  .main-link .topic-excerpt {
-    display: none;
-  }
-}

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,0 +1,17 @@
+.excerpt-toggle {
+  border: none;
+  background: transparent;
+  .mobile-view & {
+    padding: 1em 1em 0.5em;
+    border-top: 1px solid var(--primary-low);
+    width: 100%;
+    text-align: left;
+    margin-top: 0.5em;
+  }
+}
+
+body.hide-excerpt {
+  .main-link .topic-excerpt {
+    display: none;
+  }
+}

--- a/javascripts/discourse/components/topic-excerpt-toggle.gjs
+++ b/javascripts/discourse/components/topic-excerpt-toggle.gjs
@@ -1,0 +1,55 @@
+import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import icon from "discourse-common/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+export default class ExcerptToggle extends Component {
+  @service excerptState;
+  @service site;
+  @service router;
+
+  constructor() {
+    super(...arguments);
+    this.excerptState.excerptClass(this.excerptState.prefersExcerpt);
+  }
+
+  get shouldShow() {
+    const categoriesRoute =
+      this.router.currentRouteName === "discovery.categories";
+
+    if (!settings.show_toggle || categoriesRoute) {
+      return;
+    }
+
+    const isTopicHeader =
+      this.args.outletArgs?.name === "default" ||
+      this.args.outletArgs?.name === "topic.title" ||
+      this.site.mobileView;
+
+    return (
+      this.excerptState.shouldExpandPinned() &&
+      isTopicHeader &&
+      !this.args.outletArgs.bulkSelectEnabled
+    );
+  }
+
+  get buttonIcon() {
+    return this.excerptState.prefersExcerpt ? "square-check" : "far-square";
+  }
+
+  @action
+  toggleExcerpt() {
+    this.excerptState.toggleExcerpt();
+  }
+
+  <template>
+    {{#if this.shouldShow}}
+      <button {{on "click" this.toggleExcerpt}} class="excerpt-toggle">
+        {{icon this.buttonIcon}}
+        <span>{{i18n (themePrefix "show_excerpts")}}</span>
+      </button>
+    {{/if}}
+  </template>
+}

--- a/javascripts/discourse/components/topic-excerpt-toggle.gjs
+++ b/javascripts/discourse/components/topic-excerpt-toggle.gjs
@@ -10,11 +10,6 @@ export default class ExcerptToggle extends Component {
   @service site;
   @service router;
 
-  constructor() {
-    super(...arguments);
-    this.excerptState.excerptClass(this.excerptState.prefersExcerpt);
-  }
-
   get shouldShow() {
     const categoriesRoute =
       this.router.currentRouteName === "discovery.categories";
@@ -28,11 +23,7 @@ export default class ExcerptToggle extends Component {
       this.args.outletArgs?.name === "topic.title" ||
       this.site.mobileView;
 
-    return (
-      this.excerptState.shouldExpandPinned() &&
-      isTopicHeader &&
-      !this.args.outletArgs.bulkSelectEnabled
-    );
+    return isTopicHeader && !this.args.outletArgs.bulkSelectEnabled;
   }
 
   get buttonIcon() {

--- a/javascripts/discourse/components/topic-excerpt-toggle.gjs
+++ b/javascripts/discourse/components/topic-excerpt-toggle.gjs
@@ -46,7 +46,11 @@ export default class ExcerptToggle extends Component {
 
   <template>
     {{#if this.shouldShow}}
-      <button {{on "click" this.toggleExcerpt}} class="excerpt-toggle">
+      <button
+        type="button"
+        {{on "click" this.toggleExcerpt}}
+        class="excerpt-toggle"
+      >
         {{icon this.buttonIcon}}
         <span>{{i18n (themePrefix "show_excerpts")}}</span>
       </button>

--- a/javascripts/discourse/components/topic-excerpt-toggle.gjs
+++ b/javascripts/discourse/components/topic-excerpt-toggle.gjs
@@ -11,11 +11,18 @@ export default class ExcerptToggle extends Component {
   @service router;
 
   get shouldShow() {
+    if (
+      !this.site.useGlimmerTopicList ||
+      !this.excerptState.shouldApplyOverride
+    ) {
+      return false;
+    }
+
     const categoriesRoute =
       this.router.currentRouteName === "discovery.categories";
 
     if (!settings.show_toggle || categoriesRoute) {
-      return;
+      return false;
     }
 
     const isTopicHeader =

--- a/javascripts/discourse/components/topic-excerpt-toggle.gjs
+++ b/javascripts/discourse/components/topic-excerpt-toggle.gjs
@@ -19,8 +19,8 @@ export default class ExcerptToggle extends Component {
     }
 
     const isTopicHeader =
-      this.args.outletArgs?.name === "default" ||
-      this.args.outletArgs?.name === "topic.title" ||
+      this.args.outletArgs.name === "default" ||
+      this.args.outletArgs.name === "topic.title" ||
       this.site.mobileView;
 
     return isTopicHeader && !this.args.outletArgs.bulkSelectEnabled;

--- a/javascripts/discourse/initializers/init-topic-excerpt-toggle.js
+++ b/javascripts/discourse/initializers/init-topic-excerpt-toggle.js
@@ -1,0 +1,12 @@
+import { apiInitializer } from "discourse/lib/api";
+import TopicExcerptToggle from "../components/topic-excerpt-toggle";
+
+export default apiInitializer("1.8.0", (api) => {
+  const isMobile = api.container.lookup("service:site").mobileView;
+
+  if (isMobile) {
+    api.renderInOutlet("extra-nav-item", TopicExcerptToggle);
+  } else {
+    api.renderInOutlet("topic-list-heading-bottom", TopicExcerptToggle);
+  }
+});

--- a/javascripts/discourse/initializers/init-topic-excerpts.js
+++ b/javascripts/discourse/initializers/init-topic-excerpts.js
@@ -1,41 +1,17 @@
-import { getOwner } from "@ember/application";
-import { service } from "@ember/service";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { withSilencedDeprecations } from "discourse-common/lib/deprecated";
-import discourseComputed from "discourse-common/utils/decorators";
-
-const enabledCategories = settings.enabled_categories
-  .split("|")
-  .map((id) => parseInt(id, 10))
-  .filter((id) => id);
-const enabledTags = settings.enabled_tags.split("|").filter((tag) => tag);
 
 export default {
   name: "topic-excerpts-init",
 
   initialize() {
     withPluginApi("1.34.0", (api) => {
-      const discovery = api.container.lookup("service:discovery");
+      const excerptState = api.container.lookup("service:excerpt-state");
+
       api.registerValueTransformer(
         "topic-list-item-expand-pinned",
-        ({ value, context }) => {
-          const overrideEverywhere =
-            enabledCategories.length === 0 && enabledTags.length === 0;
-          const overrideInCategory = enabledCategories.includes(
-            discovery.category?.id
-          );
-          const overrideInTag = enabledTags.includes(discovery.tag?.id);
-          const overrideOnDevice = context.mobileView
-            ? settings.show_excerpts_mobile
-            : settings.show_excerpts_desktop;
-
-          if (
-            (overrideEverywhere || overrideInTag || overrideInCategory) &&
-            overrideOnDevice
-          ) {
-            return true;
-          }
-          return value; // Return default value
+        ({ value }) => {
+          return excerptState.shouldExpandPinned() || value;
         }
       );
 
@@ -44,51 +20,9 @@ export default {
         api.modifyClass("component:topic-list-item", {
           pluginId: "discourse-topic-excerpts",
 
-          excerptsRouter: service("router"),
-
-          @discourseComputed(
-            "excerptsRouter.currentRouteName",
-            "excerptsRouter.currentRoute.attributes.category.id"
-          )
-          excerptsViewingCategoryId(currentRouteName, categoryId) {
-            if (!currentRouteName.match(/^discovery\./)) {
-              return;
-            }
-            return categoryId;
-          },
-
-          @discourseComputed(
-            "excerptsRouter.currentRouteName",
-            "excerptsRouter.currentRoute.attributes.id", // For discourse instances earlier than https://github.com/discourse/discourse/commit/f7b5ff39cf
-            "excerptsRouter.currentRoute.attributes.tag.id"
-          )
-          excerptsViewingTag(currentRouteName, legacyTagId, tagId) {
-            if (!currentRouteName.match(/^tag\.show/)) {
-              return;
-            }
-            return tagId || legacyTagId;
-          },
-
-          @discourseComputed("excerptsViewingCategoryId", "excerptsViewingTag")
-          expandPinned(viewingCategory, viewingTag) {
-            const overrideEverywhere =
-              enabledCategories.length === 0 && enabledTags.length === 0;
-
-            const overrideInCategory =
-              enabledCategories.includes(viewingCategory);
-            const overrideInTag = enabledTags.includes(viewingTag);
-
-            const overrideOnDevice = getOwner(this).lookup("service:site")
-              .mobileView
-              ? settings.show_excerpts_mobile
-              : settings.show_excerpts_desktop;
-
-            return (overrideEverywhere ||
-              overrideInTag ||
-              overrideInCategory) &&
-              overrideOnDevice
-              ? true
-              : this._super();
+          expandPinned() {
+            const shouldExpand = excerptState.shouldExpandPinned();
+            return shouldExpand || this._super(...arguments);
           },
         });
       });

--- a/javascripts/discourse/initializers/init-topic-excerpts.js
+++ b/javascripts/discourse/initializers/init-topic-excerpts.js
@@ -56,7 +56,7 @@ export default {
           },
 
           @discourseComputed("excerptsViewingCategoryId", "excerptsViewingTag")
-          expandPinned(viewingCategory, viewingTag, prefersExcerpt) {
+          expandPinned(viewingCategory, viewingTag) {
             const overrideEverywhere =
               enabledCategories.length === 0 && enabledTags.length === 0;
 

--- a/javascripts/discourse/initializers/init-topic-excerpts.js
+++ b/javascripts/discourse/initializers/init-topic-excerpts.js
@@ -1,17 +1,46 @@
+import { getOwner } from "@ember/application";
+import { service } from "@ember/service";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { withSilencedDeprecations } from "discourse-common/lib/deprecated";
+import discourseComputed from "discourse-common/utils/decorators";
+
+const enabledCategories = settings.enabled_categories
+  .split("|")
+  .map((id) => parseInt(id, 10))
+  .filter((id) => id);
+const enabledTags = settings.enabled_tags.split("|").filter((tag) => tag);
 
 export default {
   name: "topic-excerpts-init",
 
   initialize() {
     withPluginApi("1.34.0", (api) => {
-      const excerptState = api.container.lookup("service:excerpt-state");
+      const discovery = api.container.lookup("service:discovery");
 
       api.registerValueTransformer(
         "topic-list-item-expand-pinned",
-        ({ value }) => {
-          return excerptState.shouldExpandPinned() || value;
+        ({ value, context }) => {
+          const overrideEverywhere =
+            enabledCategories.length === 0 && enabledTags.length === 0;
+          const overrideInCategory = enabledCategories.includes(
+            discovery.category?.id
+          );
+          const overrideInTag = enabledTags.includes(discovery.tag?.id);
+          const overrideOnDevice = context.mobileView
+            ? settings.show_excerpts_mobile
+            : settings.show_excerpts_desktop;
+
+          const prefersExcerpt = api.container.lookup(
+            "service:excerpt-state"
+          ).prefersExcerpt;
+
+          if (
+            (overrideEverywhere || overrideInTag || overrideInCategory) &&
+            overrideOnDevice
+          ) {
+            return prefersExcerpt;
+          }
+          return value; // Return default value
         }
       );
 
@@ -20,9 +49,56 @@ export default {
         api.modifyClass("component:topic-list-item", {
           pluginId: "discourse-topic-excerpts",
 
-          expandPinned() {
-            const shouldExpand = excerptState.shouldExpandPinned();
-            return shouldExpand || this._super(...arguments);
+          excerptsRouter: service("router"),
+          excerptState: service("excerpt-state"),
+
+          @discourseComputed(
+            "excerptsRouter.currentRouteName",
+            "excerptsRouter.currentRoute.attributes.category.id"
+          )
+          excerptsViewingCategoryId(currentRouteName, categoryId) {
+            if (!currentRouteName.match(/^discovery\./)) {
+              return;
+            }
+            return categoryId;
+          },
+
+          @discourseComputed(
+            "excerptsRouter.currentRouteName",
+            "excerptsRouter.currentRoute.attributes.id", // For discourse instances earlier than https://github.com/discourse/discourse/commit/f7b5ff39cf
+            "excerptsRouter.currentRoute.attributes.tag.id"
+          )
+          excerptsViewingTag(currentRouteName, legacyTagId, tagId) {
+            if (!currentRouteName.match(/^tag\.show/)) {
+              return;
+            }
+            return tagId || legacyTagId;
+          },
+
+          @discourseComputed(
+            "excerptsViewingCategoryId",
+            "excerptsViewingTag",
+            "excerptState.prefersExcerpt"
+          )
+          expandPinned(viewingCategory, viewingTag, prefersExcerpt) {
+            const overrideEverywhere =
+              enabledCategories.length === 0 && enabledTags.length === 0;
+
+            const overrideInCategory =
+              enabledCategories.includes(viewingCategory);
+            const overrideInTag = enabledTags.includes(viewingTag);
+
+            const overrideOnDevice = getOwner(this).lookup("service:site")
+              .mobileView
+              ? settings.show_excerpts_mobile
+              : settings.show_excerpts_desktop;
+
+            return (overrideEverywhere ||
+              overrideInTag ||
+              overrideInCategory) &&
+              overrideOnDevice
+              ? prefersExcerpt
+              : this._super();
           },
         });
       });

--- a/javascripts/discourse/initializers/init-topic-excerpts.js
+++ b/javascripts/discourse/initializers/init-topic-excerpts.js
@@ -31,7 +31,6 @@ export default {
           pluginId: "discourse-topic-excerpts",
 
           excerptsRouter: service("router"),
-          excerptState: service("excerpt-state"),
 
           @discourseComputed(
             "excerptsRouter.currentRouteName",
@@ -56,11 +55,7 @@ export default {
             return tagId || legacyTagId;
           },
 
-          @discourseComputed(
-            "excerptsViewingCategoryId",
-            "excerptsViewingTag",
-            "excerptState.prefersExcerpt"
-          )
+          @discourseComputed("excerptsViewingCategoryId", "excerptsViewingTag")
           expandPinned(viewingCategory, viewingTag, prefersExcerpt) {
             const overrideEverywhere =
               enabledCategories.length === 0 && enabledTags.length === 0;
@@ -78,7 +73,7 @@ export default {
               overrideInTag ||
               overrideInCategory) &&
               overrideOnDevice
-              ? prefersExcerpt
+              ? true
               : this._super();
           },
         });

--- a/javascripts/discourse/initializers/init-topic-excerpts.js
+++ b/javascripts/discourse/initializers/init-topic-excerpts.js
@@ -15,32 +15,13 @@ export default {
 
   initialize() {
     withPluginApi("1.34.0", (api) => {
-      const discovery = api.container.lookup("service:discovery");
-
       api.registerValueTransformer(
         "topic-list-item-expand-pinned",
-        ({ value, context }) => {
-          const overrideEverywhere =
-            enabledCategories.length === 0 && enabledTags.length === 0;
-          const overrideInCategory = enabledCategories.includes(
-            discovery.category?.id
-          );
-          const overrideInTag = enabledTags.includes(discovery.tag?.id);
-          const overrideOnDevice = context.mobileView
-            ? settings.show_excerpts_mobile
-            : settings.show_excerpts_desktop;
-
-          const prefersExcerpt = api.container.lookup(
-            "service:excerpt-state"
-          ).prefersExcerpt;
-
-          if (
-            (overrideEverywhere || overrideInTag || overrideInCategory) &&
-            overrideOnDevice
-          ) {
-            return prefersExcerpt;
-          }
-          return value; // Return default value
+        ({ value }) => {
+          const excerptState = api.container.lookup("service:excerpt-state");
+          return excerptState.shouldApplyOverride
+            ? excerptState.prefersExcerpt
+            : value;
         }
       );
 

--- a/javascripts/discourse/services/excerpt-state.js
+++ b/javascripts/discourse/services/excerpt-state.js
@@ -1,19 +1,45 @@
+// services/excerpt-state.js
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import Service from "@ember/service";
+import Service, { service } from "@ember/service";
 
 const EXCERPT_PREF_KEY = "showExcerpt";
-const EXCERPT_PREF = settings.show_toggle
-  ? localStorage.getItem(EXCERPT_PREF_KEY)
-  : "false";
+const enabledCategories = settings.enabled_categories
+  .split("|")
+  .map(Number)
+  .filter(Boolean);
+const enabledTags = settings.enabled_tags.split("|").filter(Boolean);
+
 export default class ExcerptState extends Service {
+  @service router;
+  @service discovery;
+  @service site;
+
   @tracked
-  prefersExcerpt = EXCERPT_PREF === null ? true : EXCERPT_PREF === "true";
+  prefersExcerpt = settings.show_toggle
+    ? localStorage.getItem(EXCERPT_PREF_KEY) !== "false"
+    : true;
+
+  get shouldApplyOverride() {
+    const overrideEverywhere =
+      enabledCategories.length === 0 && enabledTags.length === 0;
+    const overrideInCategory = enabledCategories.includes(
+      this.discovery.category?.id
+    );
+    const overrideInTag = enabledTags.includes(this.discovery.tag?.id);
+    const overrideOnDevice = this.site.mobileView
+      ? settings.show_excerpts_mobile
+      : settings.show_excerpts_desktop;
+
+    return (
+      (overrideEverywhere || overrideInTag || overrideInCategory) &&
+      overrideOnDevice
+    );
+  }
 
   @action
   toggleExcerpt() {
     this.prefersExcerpt = !this.prefersExcerpt;
-
     localStorage.setItem(EXCERPT_PREF_KEY, this.prefersExcerpt);
   }
 }

--- a/javascripts/discourse/services/excerpt-state.js
+++ b/javascripts/discourse/services/excerpt-state.js
@@ -12,51 +12,10 @@ export default class ExcerptState extends Service {
   @tracked
   prefersExcerpt = EXCERPT_PREF === null ? true : EXCERPT_PREF === "true";
 
-  get enabledCategories() {
-    return settings.enabled_categories
-      .split("|")
-      .map((id) => parseInt(id, 10))
-      .filter(Boolean);
-  }
-
-  get enabledTags() {
-    return settings.enabled_tags.split("|").filter(Boolean);
-  }
-
-  shouldExpandPinned() {
-    const isMobile = this.site?.mobileView;
-
-    const overrideEverywhere =
-      this.enabledCategories.length === 0 && this.enabledTags.length === 0;
-
-    const overrideInCategory = this.enabledCategories.includes(
-      this.discovery.category?.id
-    );
-    const overrideInTag = this.enabledTags.includes(this.discovery.tag?.id);
-
-    const overrideOnDevice = isMobile
-      ? settings.show_excerpts_mobile
-      : settings.show_excerpts_desktop;
-
-    return (
-      (overrideEverywhere || overrideInTag || overrideInCategory) &&
-      overrideOnDevice
-    );
-  }
-
   @action
   toggleExcerpt() {
     this.prefersExcerpt = !this.prefersExcerpt;
-    localStorage.setItem(EXCERPT_PREF_KEY, this.prefersExcerpt);
-    this.excerptClass(this.prefersExcerpt);
-  }
 
-  @action
-  excerptClass(show) {
-    if (show) {
-      document.body.classList.remove("hide-excerpt");
-    } else {
-      document.body.classList.add("hide-excerpt");
-    }
+    localStorage.setItem(EXCERPT_PREF_KEY, this.prefersExcerpt);
   }
 }

--- a/javascripts/discourse/services/excerpt-state.js
+++ b/javascripts/discourse/services/excerpt-state.js
@@ -1,14 +1,12 @@
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import Service, { service } from "@ember/service";
+import Service from "@ember/service";
 
 const EXCERPT_PREF_KEY = "showExcerpt";
-const EXCERPT_PREF = localStorage.getItem(EXCERPT_PREF_KEY);
-
+const EXCERPT_PREF = settings.show_toggle
+  ? localStorage.getItem(EXCERPT_PREF_KEY)
+  : "false";
 export default class ExcerptState extends Service {
-  @service site;
-  @service discovery;
-
   @tracked
   prefersExcerpt = EXCERPT_PREF === null ? true : EXCERPT_PREF === "true";
 

--- a/javascripts/discourse/services/excerpt-state.js
+++ b/javascripts/discourse/services/excerpt-state.js
@@ -1,0 +1,62 @@
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import Service, { service } from "@ember/service";
+
+const EXCERPT_PREF_KEY = "showExcerpt";
+const EXCERPT_PREF = localStorage.getItem(EXCERPT_PREF_KEY);
+
+export default class ExcerptState extends Service {
+  @service site;
+  @service discovery;
+
+  @tracked
+  prefersExcerpt = EXCERPT_PREF === null ? true : EXCERPT_PREF === "true";
+
+  get enabledCategories() {
+    return settings.enabled_categories
+      .split("|")
+      .map((id) => parseInt(id, 10))
+      .filter(Boolean);
+  }
+
+  get enabledTags() {
+    return settings.enabled_tags.split("|").filter(Boolean);
+  }
+
+  shouldExpandPinned() {
+    const isMobile = this.site?.mobileView;
+
+    const overrideEverywhere =
+      this.enabledCategories.length === 0 && this.enabledTags.length === 0;
+
+    const overrideInCategory = this.enabledCategories.includes(
+      this.discovery.category?.id
+    );
+    const overrideInTag = this.enabledTags.includes(this.discovery.tag?.id);
+
+    const overrideOnDevice = isMobile
+      ? settings.show_excerpts_mobile
+      : settings.show_excerpts_desktop;
+
+    return (
+      (overrideEverywhere || overrideInTag || overrideInCategory) &&
+      overrideOnDevice
+    );
+  }
+
+  @action
+  toggleExcerpt() {
+    this.prefersExcerpt = !this.prefersExcerpt;
+    localStorage.setItem(EXCERPT_PREF_KEY, this.prefersExcerpt);
+    this.excerptClass(this.prefersExcerpt);
+  }
+
+  @action
+  excerptClass(show) {
+    if (show) {
+      document.body.classList.remove("hide-excerpt");
+    } else {
+      document.body.classList.add("hide-excerpt");
+    }
+  }
+}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,5 +4,5 @@ en:
     settings:
       enabled_categories: Enable excerpts in specific categories. Leave both categories and tags blank to show excerpts on all routes.
       enabled_tags: Enable excerpts in specific tags. Leave both categories and tags blank to show excerpts on all routes.
-      show_toggle: When excerpts are visible, allow users to toggle them off.
+      show_toggle: When excerpts are visible, allow users to toggle them off. Only supported on the <a href='https://meta.discourse.org/t/upcoming-topic-list-changes-how-to-prepare-themes-and-plugins/343404'>glimmer topic list<a/>
   show_excerpts: Show Excerpts

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,3 +4,5 @@ en:
     settings:
       enabled_categories: Enable excerpts in specific categories. Leave both categories and tags blank to show excerpts on all routes.
       enabled_tags: Enable excerpts in specific tags. Leave both categories and tags blank to show excerpts on all routes.
+      show_toggle: When excerpts are visible, allow users to toggle them off.
+  show_excerpts: Show Excerpts

--- a/settings.yml
+++ b/settings.yml
@@ -10,4 +10,4 @@ enabled_tags:
   default: ""
 show_toggle:
   type: bool
-  default: true
+  default: false

--- a/settings.yml
+++ b/settings.yml
@@ -8,3 +8,6 @@ enabled_tags:
   type: list
   list_type: simple
   default: ""
+show_toggle:
+  type: bool
+  default: true

--- a/spec/system/topic_list_item_spec.rb
+++ b/spec/system/topic_list_item_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Viewing the search banner", type: :system do
+RSpec.describe "Viewing topic excerpts", type: :system do
   fab!(:theme) { upload_theme_component }
   fab!(:category)
   fab!(:category_2) { Fabricate(:category) }
@@ -62,5 +62,38 @@ RSpec.describe "Viewing the search banner", type: :system do
       topic_list_page.topic_list_item_class(topic_2) + " .topic-excerpt",
       text: "This is not expanded text",
     )
+  end
+
+  context "when show_toggle setting is disabled" do
+    before do
+      theme.update_setting(:show_toggle, false)
+      theme.save!
+    end
+
+    it "does not show the excerpt toggle button on the topic list" do
+      visit("/c/#{category.id}")
+      expect(page).not_to have_selector(".excerpt-toggle")
+    end
+  end
+
+  context "when show_toggle setting is enabled" do
+    before do
+      theme.update_setting(:show_toggle, true)
+      theme.save!
+    end
+
+    it "shows the excerpt toggle button on the topic list" do
+      visit("/c/#{category.id}")
+
+      expect(page).to have_selector(".excerpt-toggle")
+    end
+
+    it "toggles the excerpt when the button is clicked" do
+      visit("/c/#{category.id}")
+
+      find(".excerpt-toggle").click
+
+      expect(page).not_to have_css(".topic-excerpt")
+    end
   end
 end


### PR DESCRIPTION
This adds an optional toggle (disabled by default) that allows individuals to turn off excerpts if desired. 

I also ended up moving various parts of the initializer to a service so they can be used by components. 

This will only work on the glimmer topic list, due to some limitations with the legacy version. 

Desktop:

![image](https://github.com/user-attachments/assets/7cf90bea-0a0b-4b0b-8e08-3d6a721310c4)

![image](https://github.com/user-attachments/assets/262368d4-31e8-4244-8c96-01b98b56e55f)

Mobile: 

<img src="https://github.com/user-attachments/assets/aa28a9ad-167a-49ab-ae12-3605261e6bd1" width="300"> 

