### PR TITLE
Fix: Excerpt layout when thumbnail is present

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -10,3 +10,9 @@
     margin-top: 0.5em;
   }
 }
+
+.topic-list .topic-list-thumbnail ~ .topic-excerpt {
+  display: table;
+  table-layout: fixed;
+  width: 100%;
+}


### PR DESCRIPTION
This PR tweaks fixes an issue with the topic excerpt layout only if the topic thumbnail is present. This is integrating code from a [hotfix](https://meta.discourse.org/t/layout-issue-podcaster-community/358929/4).

## Before
This excerpt is causing the page to have horizontal scrollbars.
![Screenshot 2025-03-26 at 08 49 51](https://github.com/user-attachments/assets/a3aa03d9-86cf-400d-803e-cbc07ba2efb3)

## After
![image](https://github.com/user-attachments/assets/c2fd5ccf-d0f9-4de6-8845-e806d89536df)
